### PR TITLE
PHP 8 and open_basedir related changes

### DIFF
--- a/src/voku/db/DB.php
+++ b/src/voku/db/DB.php
@@ -1073,9 +1073,6 @@ final class DB
                     $var = UTF8::html_entity_decode($var);
                 }
 
-                /** @noinspection PhpUsageOfSilenceOperatorInspection */
-                $var = @\get_magic_quotes_gpc() ? \stripslashes($var) : $var;
-
                 if (
                     $this->mysqli_link
                     &&

--- a/src/voku/db/DB.php
+++ b/src/voku/db/DB.php
@@ -334,7 +334,7 @@ final class DB
             &&
             ($defaultSocket = @\ini_get('mysqli.default_socket'))
             &&
-            \is_readable($defaultSocket)
+            @\is_readable($defaultSocket)
         ) {
             $this->socket = $defaultSocket;
         }


### PR DESCRIPTION
- function get_magic_quotes_gpc() was removed in PHP v8
- is_readable always throws an notice if used in conjunction with open_basedir

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/voku/simple-mysqli/51)
<!-- Reviewable:end -->
